### PR TITLE
Fix tests

### DIFF
--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -20,7 +20,7 @@ describe('constructor', () => {
 
   test('calls normalize.js', () => {
     (() => new DevReact('dir'))()
-    expect(normalize.calledOnceWith('dir'))
+    expect(normalize.calledOnceWith('dir')).toBe(true)
   })
 })
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -10,6 +10,7 @@ import chokidar from 'chokidar'
 afterEach(reset)
 afterEach(() => {
   normalize.resetHistory()
+  chokidar.watch.resetHistory()
 })
 
 describe('constructor', () => {
@@ -29,7 +30,7 @@ test('start', async () => {
   const devReact = new DevReact('dir')
   const start = devReact.start()
   await noResolve(start, tick())
-  chokidar.watch.calledOnceWith('dir', { depth: 0 })
+  expect(chokidar.watch.calledOnceWith('dir', { depth: 0 })).toBe(true)
   chokidar.watch.getCall(0).returnValue.emit('ready')
   await start
 })


### PR DESCRIPTION
Before we were using `fake.calledOnceWith()`, thinking that it would throw an error if it wasn't called once with the value. The `calledOnceWith()` method actually returns `true` or `false`, and doesn't make any assertions. So we wrapped it in `expect().toBe(true)`